### PR TITLE
Change Playground Functionality by Implementing Context and Reducer

### DIFF
--- a/src/deps.ts
+++ b/src/deps.ts
@@ -1,4 +1,5 @@
 export { ensureDir } from "https://deno.land/std@0.135.0/fs/mod.ts";
+export { bundle } from "https://deno.land/x/emit@0.21.1/mod.ts";
 export * from "https://deno.land/x/mongo@v0.31.2/mod.ts";
 
 export * from "npm:superstruct@1.0.3";

--- a/src/server/playground/comp/ManagedLesanContext.tsx
+++ b/src/server/playground/comp/ManagedLesanContext.tsx
@@ -1,0 +1,330 @@
+/** @jsx h */
+import { createContext, h } from "https://esm.sh/preact@10.5.15";
+import {
+  useRef,
+  useState,
+  useReducer,
+  useMemo,
+  useCallback,
+  useContext,
+} from "https://esm.sh/preact@10.5.15/hooks";
+
+// A generic Type to handle customized Objects
+interface TObjectArray<T> {
+  [key: string]: T;
+}
+
+/* --------------------------- Action Types Start --------------------------- */
+enum ACTION_TYPE {
+  SET_SERVICE = "SET_SELECTED_SERVICE",
+  SET_METHOD = "SET_SELECTED_METHOD",
+  SET_SCHEMA = "SET_SCHEMA",
+  SET_ACT = "SET_ACT",
+  SET_POST_FIELDS = "SET_POST_FIELDS",
+  RESET_POST_FIELDS = "RESET_POST_FIELDS",
+  SET_GET_FIELDS = "SET_GET_FIELDS",
+  RESET_GET_FIELDS = "RESET_GET_FIELDS",
+  SET_FORM_DATA = "SET_FORM_DATA",
+  SET_HEADER = "SET_HEADER",
+  SET_HISTORY = "ADD_HISTORY",
+  SET_RESPONSE = "SET_RESPONSE",
+}
+/* --------------------------- Action Types End --------------------------- */
+
+/* ------------------------- Type Definitions Start ------------------------- */
+type THistory = {
+  request: string;
+  response: string;
+  id: string;
+};
+// TODO: The any Types have to remove and fix
+interface IState {
+  service: string;
+  method: string;
+  schema: string;
+  act: string;
+  postFields: any;
+  getFields: any;
+  formData: any;
+  headers: TObjectArray<string>;
+  history: THistory[] | null;
+  response: [];
+  setService: (payload: string) => void;
+  setMethod: (payload: string) => void;
+  setSchema: (payload: string) => void;
+  setAct: (payload: string) => void;
+  setPostFields: (payload: string) => void;
+  resetPostFields: () => void;
+  setGetFields: (payload: string) => void;
+  resetGetFields: () => void;
+  setFormData: (payload: any) => void;
+  setHeader: (payload: TObjectArray<string>) => void;
+  setHistory: (payload: THistory[]) => void;
+  setResponse: (payload: THistory[]) => void;
+}
+
+type TAction =
+  | {
+      type: ACTION_TYPE.SET_SERVICE;
+      payload: string;
+    }
+  | {
+      type: ACTION_TYPE.SET_METHOD;
+      payload: string;
+    }
+  | {
+      type: ACTION_TYPE.SET_SCHEMA;
+      payload: string;
+    }
+  | {
+      type: ACTION_TYPE.SET_ACT;
+      payload: string;
+    }
+  | {
+      type: ACTION_TYPE.SET_POST_FIELDS;
+      payload: string;
+    }
+  | {
+      type: ACTION_TYPE.RESET_POST_FIELDS;
+      payload: string;
+    }
+  | {
+      type: ACTION_TYPE.SET_GET_FIELDS;
+      payload: string;
+    }
+  | {
+      type: ACTION_TYPE.RESET_GET_FIELDS;
+      payload: string;
+    }
+  | {
+      type: ACTION_TYPE.SET_FORM_DATA;
+      payload: string;
+    }
+  | {
+      type: ACTION_TYPE.SET_HEADER;
+      payload: TObjectArray<string>;
+    }
+  | {
+      type: ACTION_TYPE.SET_HISTORY;
+      payload: THistory[];
+    }
+  | {
+      type: ACTION_TYPE.SET_RESPONSE;
+      payload: THistory[];
+    };
+/* -------------------------- Type Definitions End -------------------------- */
+
+// TODO: Have to Find Someway to Prevent from Rewriting Function Types
+const initialState: IState = {
+  service: "",
+  method: "",
+  schema: "",
+  act: "",
+  postFields: {},
+  getFields: {},
+  formData: {},
+  headers: { Authorization: "" },
+  history: [],
+  response: [],
+  setService: () => ({}),
+  setMethod: () => ({}),
+  setSchema: () => ({}),
+  setAct: () => ({}),
+  setPostFields: () => ({}),
+  resetPostFields: () => ({}),
+  setGetFields: () => ({}),
+  resetGetFields: () => ({}),
+  setFormData: () => ({}),
+  setHeader: () => ({}),
+  setHistory: () => ({}),
+  setResponse: () => ({}),
+};
+
+const LesanContext = createContext<IState>(initialState);
+
+function lesanReducer(state: IState, action: TAction): IState {
+  const { type, payload } = action;
+  switch (type) {
+    case ACTION_TYPE.SET_SERVICE: {
+      return {
+        ...state,
+        service: payload,
+      };
+    }
+    case ACTION_TYPE.SET_METHOD: {
+      return {
+        ...state,
+        method: payload,
+      };
+    }
+    case ACTION_TYPE.SET_SCHEMA: {
+      return {
+        ...state,
+        schema: payload,
+      };
+    }
+    case ACTION_TYPE.SET_ACT: {
+      return {
+        ...state,
+        act: payload,
+      };
+    }
+    case ACTION_TYPE.SET_POST_FIELDS: {
+      return {
+        ...state,
+        postFields: payload,
+      };
+    }
+    case ACTION_TYPE.RESET_POST_FIELDS: {
+      return {
+        ...state,
+        postFields: {},
+      };
+    }
+    case ACTION_TYPE.SET_GET_FIELDS: {
+      return {
+        ...state,
+        getFields: payload,
+      };
+    }
+    case ACTION_TYPE.RESET_GET_FIELDS: {
+      return {
+        ...state,
+        getFields: {},
+      };
+    }
+    case ACTION_TYPE.SET_FORM_DATA: {
+      return {
+        ...state,
+        formData: payload,
+      };
+    }
+    case ACTION_TYPE.SET_HEADER: {
+      return {
+        ...state,
+        headers: payload,
+      };
+    }
+    case ACTION_TYPE.SET_HISTORY: {
+      return {
+        ...state,
+        history: payload,
+      };
+    }
+    case ACTION_TYPE.SET_RESPONSE: {
+      return {
+        ...state,
+        history: payload,
+      };
+    }
+    default:
+      throw new Error(`Unhandled action type`);
+  }
+}
+
+const LesanProvider = (props: any) => {
+  const [state, dispatch] = useReducer(lesanReducer, initialState);
+
+  const setService = useCallback(
+    (payload: string) => dispatch({ type: ACTION_TYPE.SET_SERVICE, payload }),
+    [dispatch]
+  );
+
+  const setMethod = useCallback(
+    (payload: string) => dispatch({ type: ACTION_TYPE.SET_METHOD, payload }),
+    [dispatch]
+  );
+
+  const setSchema = useCallback(
+    (payload: string) => dispatch({ type: ACTION_TYPE.SET_SCHEMA, payload }),
+    [dispatch]
+  );
+
+  const setAct = useCallback(
+    (payload: string) => dispatch({ type: ACTION_TYPE.SET_ACT, payload }),
+    [dispatch]
+  );
+
+  const setPostFields = useCallback(
+    (payload: string) =>
+      dispatch({ type: ACTION_TYPE.SET_POST_FIELDS, payload }),
+    [dispatch]
+  );
+
+  const resetPostFields = useCallback(
+    (payload: string) =>
+      dispatch({ type: ACTION_TYPE.RESET_POST_FIELDS, payload }),
+    [dispatch]
+  );
+
+  const setGetFields = useCallback(
+    (payload: string) =>
+      dispatch({ type: ACTION_TYPE.SET_GET_FIELDS, payload }),
+    [dispatch]
+  );
+
+  const resetGetFields = useCallback(
+    (payload: string) =>
+      dispatch({ type: ACTION_TYPE.RESET_GET_FIELDS, payload }),
+    [dispatch]
+  );
+  const setFormData = useCallback(
+    (payload: any) => dispatch({ type: ACTION_TYPE.SET_FORM_DATA, payload }),
+    [dispatch]
+  );
+
+  const setHeader = useCallback(
+    (payload: TObjectArray<string>) =>
+      dispatch({ type: ACTION_TYPE.SET_HEADER, payload }),
+    [dispatch]
+  );
+
+  const setHistory = useCallback(
+    (payload: THistory[]) =>
+      dispatch({ type: ACTION_TYPE.SET_HISTORY, payload }),
+    [dispatch]
+  );
+
+  const setResponse = useCallback(
+    (payload: THistory[]) =>
+      dispatch({ type: ACTION_TYPE.SET_RESPONSE, payload }),
+    [dispatch]
+  );
+
+  const value = useMemo(
+    () => ({
+      ...state,
+      setService,
+      setMethod,
+      setSchema,
+      setAct,
+      setPostFields,
+      resetPostFields,
+      setGetFields,
+      resetGetFields,
+      setFormData,
+      setHeader,
+      setHistory,
+      setResponse,
+    }),
+    [state]
+  );
+
+  return <LesanContext.Provider value={value} {...props} />;
+};
+
+const useLesan = () => {
+  const context = useContext(LesanContext);
+  if (context === undefined) {
+    console.warn(`useLesan must be used within a LesanProvider`);
+  }
+  return context;
+};
+
+const ManagedLesanContext = (props: { children: h.JSX.Element }) => {
+  const { children } = props;
+
+  return <LesanProvider>{children}</LesanProvider>;
+};
+
+export { ManagedLesanContext, useLesan };

--- a/src/server/playground/comp/ManagedLesanContext.tsx
+++ b/src/server/playground/comp/ManagedLesanContext.tsx
@@ -48,7 +48,7 @@ interface IState {
   formData: any;
   headers: TObjectArray<string>;
   history: THistory[] | null;
-  response: [];
+  response: [] | null;
   setService: (payload: string) => void;
   setMethod: (payload: string) => void;
   setSchema: (payload: string) => void;
@@ -125,7 +125,7 @@ const initialState: IState = {
   formData: {},
   headers: { Authorization: "" },
   history: [],
-  response: [],
+  response: null,
   setService: () => ({}),
   setMethod: () => ({}),
   setSchema: () => ({}),

--- a/src/server/playground/comp/preact.tsx
+++ b/src/server/playground/comp/preact.tsx
@@ -47,20 +47,21 @@ export const Page = () => {
     });
   }, []);
 
-  const uid = function() {
+  const uid = function () {
     return Date.now().toString(36) + Math.random().toString(36).substr(2);
   };
 
   const handleChange = (event: any) => {
     const { name, value, type, alt } = event.target;
-    setFormData(() => ({
+    setFormData({
       ...formData,
-      [name]: type === "number"
-        ? Number(value)
-        : alt === "array" || alt === "boolean"
-        ? JSON.parse(value)
-        : value,
-    }));
+      [name]:
+        type === "number"
+          ? Number(value)
+          : alt === "array" || alt === "boolean"
+          ? JSON.parse(value)
+          : value,
+    });
   };
 
   const deepen = (obj: Record<string, any>) => {
@@ -130,34 +131,31 @@ export const Page = () => {
 
   const renderGetFileds = (getField: any, keyName: string, margin: number) => {
     return (
-      // style={{ marginLeft: `${margin + 10}px` }}
       <div style={{ marginLeft: `${margin + 10}px` }}>
         <h1 style={{ marginLeft: "0" }}>{keyName} :</h1>
         {Object.keys(getField["schema"]).map((childKeys) => {
-          return getField["schema"][childKeys].type === "enums"
-            ? (
-              <div
-                className="input-container"
-                style={{ marginLeft: `${margin + 10}px` }}
-              >
-                <label htmlFor={childKeys}>{childKeys}:</label>
-                <input
-                  placeholder={`${keyName}.${childKeys}`}
-                  type="number"
-                  id={`${keyName}.${childKeys}`}
-                  value={(formData as any)[`get.${keyName}.${childKeys}`]}
-                  name={`get.${keyName}.${childKeys}`}
-                  onChange={handleChange}
-                />
-              </div>
+          return getField["schema"][childKeys].type === "enums" ? (
+            <div
+              className="input-container"
+              style={{ marginLeft: `${margin + 10}px` }}
+            >
+              <label htmlFor={childKeys}>{childKeys}:</label>
+              <input
+                placeholder={`${keyName}.${childKeys}`}
+                type="number"
+                id={`${keyName}.${childKeys}`}
+                value={(formData as any)[`get.${keyName}.${childKeys}`]}
+                name={`get.${keyName}.${childKeys}`}
+                onChange={handleChange}
+              />
+            </div>
+          ) : (
+            renderGetFileds(
+              getField["schema"][childKeys],
+              `${keyName}.${childKeys}`,
+              margin + 10
             )
-            : (
-              renderGetFileds(
-                getField["schema"][childKeys],
-                `${keyName}.${childKeys}`,
-                margin + 10,
-              )
-            );
+          );
         })}
       </div>
     );
@@ -283,7 +281,9 @@ export const Page = () => {
             >
               <option value=""></option>
               {Object.keys((actsObj as any)[service][method][schema]).map(
-                (schema) => <option value={schema}>{schema}</option>,
+                (schema) => (
+                  <option value={schema}>{schema}</option>
+                )
               )}
             </select>
           </div>
@@ -304,9 +304,11 @@ export const Page = () => {
                       id={setField}
                       value={(formData as any)[`set.${setField}`]}
                       name={`set.${setField}`}
-                      type={postFields[setField]["type"] === "number"
-                        ? "number"
-                        : "string"}
+                      type={
+                        postFields[setField]["type"] === "number"
+                          ? "number"
+                          : "string"
+                      }
                       alt={postFields[setField]["type"]}
                       onChange={handleChange}
                     />
@@ -318,23 +320,21 @@ export const Page = () => {
               <div className="set-container">
                 {Object.keys(getFields).map((getField) => {
                   return ((getFields as any)[getField] as any).type ===
-                      "enums"
-                    ? (
-                      <div className="input-container">
-                        <label htmlFor={getField}>{getField}:</label>
-                        <input
-                          placeholder={getField}
-                          id={getField}
-                          value={(formData as any)[`get.${getField}`]}
-                          name={`get.${getField}`}
-                          type="number"
-                          onChange={handleChange}
-                        />
-                      </div>
-                    )
-                    : (
-                      renderGetFileds((getFields as any)[getField], getField, 0)
-                    );
+                    "enums" ? (
+                    <div className="input-container">
+                      <label htmlFor={getField}>{getField}:</label>
+                      <input
+                        placeholder={getField}
+                        id={getField}
+                        value={(formData as any)[`get.${getField}`]}
+                        name={`get.${getField}`}
+                        type="number"
+                        onChange={handleChange}
+                      />
+                    </div>
+                  ) : (
+                    renderGetFileds((getFields as any)[getField], getField, 0)
+                  );
                 })}
               </div>
               <button className="btn btn-submit" type="submit">

--- a/src/server/playground/hydrate.tsx
+++ b/src/server/playground/hydrate.tsx
@@ -1,0 +1,5 @@
+/** @jsx h */
+import { h, hydrate } from "https://esm.sh/preact@10.5.15";
+import { Page } from "./comp/preact.tsx";
+
+hydrate(<Page />, document.getElementById("root")!);

--- a/src/server/playground/hydrate.tsx
+++ b/src/server/playground/hydrate.tsx
@@ -1,5 +1,11 @@
 /** @jsx h */
 import { h, hydrate } from "https://esm.sh/preact@10.5.15";
 import { Page } from "./comp/preact.tsx";
+import { ManagedLesanContext } from "./comp/ManagedLesanContext.tsx";
 
-hydrate(<Page />, document.getElementById("root")!);
+hydrate(
+  <ManagedLesanContext>
+    <Page />
+  </ManagedLesanContext>,
+  document.getElementById("root")!
+);

--- a/src/server/playground/mod.tsx
+++ b/src/server/playground/mod.tsx
@@ -6,6 +6,7 @@ import { bundle } from "../../deps.ts";
 import { Services } from "../../mod.ts";
 import { ISchema } from "../../models/mod.ts";
 import { Page } from "./comp/preact.tsx";
+import { ManagedLesanContext } from "./comp/ManagedLesanContext.tsx";
 
 const getCSSFile = async () => {
   const url = new URL("./css/index.css", import.meta.url);
@@ -18,7 +19,7 @@ const getCSSFile = async () => {
 export const runPlayground = async (
   request: Request,
   schemasObj: ISchema,
-  actsObj: Services,
+  actsObj: Services
 ) => {
   const url = new URL("./hydrate.tsx", import.meta.url);
 
@@ -37,13 +38,15 @@ export const runPlayground = async (
       JSON.stringify({ schemas: schemasObj, acts: actsObj }),
       {
         headers: { "content-type": "application/json" },
-      },
+      }
     );
   };
 
   const getSsrReact = () => {
     const body = renderToString(
-      <Page />,
+      <ManagedLesanContext>
+        <Page />
+      </ManagedLesanContext>
     );
 
     const html = `<!DOCTYPE html>
@@ -51,7 +54,7 @@ export const runPlayground = async (
       <head>
         <meta charset="UTF-8">
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
-        <link rel="stylesheet" href="http://localhost:8000/static/index.css"> 
+        <link rel="stylesheet" href="http://localhost:8000/static/index.css">
         <title>Lesan Playground</title>
       </head>
       <body >


### PR DESCRIPTION
I add functionality to replace all of the playground states with react reducer and context. 

I replaced all new reducer functions with the previous state in `src/server/playground/comp/preact.tsx`

**To use this functionality, we just need to wrap whole the `App` with `ManagedLesanContext` !**