### PR TITLE
♻️ Refactor Deno imports and strengthen types

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -10,6 +10,15 @@
   },
   "publish": {
     "include": ["src", "mod.ts", "README.md", "LICENSE"],
-    "exclude": ["tests", "examples", "docs", "node_modules"]
+    "exclude": [
+      "tests",
+      "examples",
+      "docs",
+      "node_modules",
+      "!src/server/playground/dist/bundleContent.ts"
+    ]
+  },
+  "compilerOptions": {
+    "lib": ["deno.ns", "dom", "esnext"]
   }
 }

--- a/src/adapters/deno/bundler.adapter.ts
+++ b/src/adapters/deno/bundler.adapter.ts
@@ -57,7 +57,7 @@ export class DenoBundlerAdapter implements BundlerAdapter {
       }
 
       // Use deno_emit for bundling
-      const { bundle } = await import("https://deno.land/x/emit@0.38.2/mod.ts");
+      const { bundle } = await import("jsr:@deno/emit@0.38.2");
       const result = await bundle(entryUrl, {
         compilerOptions: this.buildCompilerOptions(options),
         importMap: options?.importMap
@@ -113,7 +113,7 @@ export class DenoBundlerAdapter implements BundlerAdapter {
       const tempUrl = `data:application/typescript;base64,${btoa(code)}`;
 
       // Use deno_emit bundle function
-      const { bundle } = await import("https://deno.land/x/emit@0.38.2/mod.ts");
+      const { bundle } = await import("jsr:@deno/emit@0.38.2");
       const result = await bundle(new URL(tempUrl), {
         compilerOptions: this.buildCompilerOptions(options),
         importMap: options?.importMap
@@ -176,7 +176,7 @@ export class DenoBundlerAdapter implements BundlerAdapter {
     try {
       // Use deno_emit transpile function with a proper URL
       const { transpile } = await import(
-        "https://deno.land/x/emit@0.38.2/mod.ts"
+        "jsr:@deno/emit@0.38.2"
       );
       const url = new URL("file:///main.ts");
       const result = await transpile(url, {

--- a/src/adapters/deno/http.adapter.ts
+++ b/src/adapters/deno/http.adapter.ts
@@ -153,7 +153,7 @@ export const denoHttpAdapter: HttpServerAdapter = {
 
       // Use Deno's serveFile helper
       const { serveFile } = await import(
-        "https://deno.land/std@0.224.0/http/file_server.ts"
+        "jsr:@std/http@1/file-server"
       );
       const response = await serveFile(request, filePath);
 

--- a/src/context.ts
+++ b/src/context.ts
@@ -17,47 +17,49 @@ let context: LesanContenxt = {
 /**
  * @returns The contextObj
  */
-const getContextModel = () => context;
+const getContextModel = (): LesanContenxt => context;
 
 /**
  * @returns The contextObj
  */
 const setContext = (
   obj: Record<string, any>,
-) => (context = { ...getContextModel(), ...obj });
+): LesanContenxt => (context = { ...getContextModel(), ...obj });
 /**
  * asigne all of value that we want to carry
  *  @param con - objects of key , value
  * @returns nothing
  */
-const addContexts = (con: LesanContenxt) => context = con;
+const addContexts = (con: LesanContenxt): LesanContenxt => context = con;
 
 /**
  * add values to previous values that we want to carry
  *  @param con - objects of key , value
  * @returns nothing
  */
-const addContext = (con: LesanContenxt) => context = { ...context, con };
+const addContext = (con: LesanContenxt): LesanContenxt =>
+  context = { ...context, con };
 /**
  * add Request to Context because the requeste may be required in later functions
  *  @param con - request of user
  * @returns nothing
  */
-const addReqToContext = (con: Request) => context["Request"] = con;
+const addReqToContext = (con: Request): Request => context["Request"] = con;
 
 /**
  * add Request Header to Context because the requeste may be required in later functions
  *  @param con - Headers of user
  * @returns nothing
  */
-const addHeaderToContext = (con: Headers) => context["Headers"] = con;
+const addHeaderToContext = (con: Headers): Headers => context["Headers"] = con;
 
 /**
  * add Request Header to Context because the requeste may be required in later functions
  *  @param con - Headers of user
  * @returns nothing
  */
-const addBodyToContext = (body: TLesanBody) => context["body"] = body;
+const addBodyToContext = (body: TLesanBody): TLesanBody =>
+  context["body"] = body;
 
 /**
  * this function is create for define all things in local scope

--- a/src/core/acts/acts.ts
+++ b/src/core/acts/acts.ts
@@ -69,7 +69,32 @@ import { ActInp, Acts, Services } from "./types.ts";
  * @param {Services} acts - is type of Services for get ServiceKeys in function
  * @returns - return objects of all functions that define in this function
  */
-export const acts = (acts: Services) => {
+export const acts = (acts: Services): {
+  setAct: (actInp: ActInp) => ReturnType<typeof setAct>;
+  getServiceKeys: () => ReturnType<typeof getServiceKeys>;
+  getActs: (schema: string) => ReturnType<typeof getActs>;
+  getActsKeys: (
+    service: keyof typeof acts,
+    schema: string,
+  ) => ReturnType<typeof getActsKeys>;
+  getActKeys: (schema: string) => ReturnType<typeof getActKeys>;
+  getAct: (
+    service: keyof typeof acts,
+    schema: string,
+    actName: string,
+  ) => ReturnType<typeof getAct>;
+  getAtcsWithServices: () => ReturnType<typeof getAtcsWithServices>;
+  getMainActs: () => ReturnType<typeof getMainActs>;
+  getMainAct: (
+    schema: string,
+    actName: string,
+  ) => ReturnType<typeof getMainAct>;
+  setService: (
+    serviceName: keyof typeof acts,
+    service: Acts | string,
+  ) => ReturnType<typeof setService>;
+  getService: (service: keyof typeof acts) => ReturnType<typeof getService>;
+} => {
   return {
     setAct: (actInp: ActInp) => setAct(acts, actInp),
     getServiceKeys: () => getServiceKeys(acts),

--- a/src/core/odm/mod.ts
+++ b/src/core/odm/mod.ts
@@ -5,7 +5,20 @@ import { assert, enums } from "../../npmDeps.ts";
 import { throwError } from "../utils/throwError.ts";
 import { newModel, OptionType } from "./newModel/mod.ts";
 
-export const odm = (schemasObj: TSchemas) => {
+export const odm = (schemasObj: TSchemas): {
+  setDb: (db: Db) => Db;
+  getCollection: (
+    collection: string,
+  ) => import("../../npmDeps.ts").Collection<
+    import("../../npmDeps.ts").Document
+  >;
+  newModel: <PF extends IPureFields, TR extends IRelationsFileds>(
+    name: string,
+    pureFields: PF,
+    relations: TR,
+    options?: OptionType<PF>,
+  ) => any;
+} => {
   let mongoDb: Db;
 
   const setDb = (db: Db) => (mongoDb = db);

--- a/src/core/odm/relation/removeRelation.ts
+++ b/src/core/odm/relation/removeRelation.ts
@@ -208,7 +208,7 @@ export const removeRelation = async <TR extends IRelationsFileds>({
         } else {
           //TODO in ghesmat bayad dorost beshe chon inja ham allan momkene limit dashte bashim va agar be limit reside bashe bayad peyda kone documet badi ro va jaygozin kone bejaye faght $pull kardan khali
           await db.collection(collection).updateOne({ _id: foundedDoc!._id }, {
-            $pull: { [rel]: { _id: { $in: relations[rel]?._ids } } },
+            $pull: { [rel]: { _id: { $in: relations[rel]?._ids } } } as any,
           });
         }
       }

--- a/src/lesan.ts
+++ b/src/lesan.ts
@@ -5,7 +5,14 @@ import { odm } from "./core/odm/mod.ts";
 import { lesanServer } from "./server/mod.ts";
 import { generateSchemTypes } from "./core/types/mod.ts";
 
-export const lesan = () => {
+export const lesan = (): {
+  schemas: ReturnType<typeof schemas>;
+  acts: ReturnType<typeof acts>;
+  odm: ReturnType<typeof odm>;
+  runServer: ReturnType<typeof lesanServer>;
+  contextFns: typeof contextFns;
+  generateSchemTypes: () => ReturnType<typeof generateSchemTypes>;
+} => {
   const schemasObj: TSchemas = {};
 
   const actsObj: Services = {

--- a/src/npmDeps.ts
+++ b/src/npmDeps.ts
@@ -68,7 +68,6 @@ export {
   BSONRegExp,
   BSONSymbol,
   BSONType,
-  CancellationToken,
   ChangeStream,
   ClientEncryption,
   ClientSession,

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,9 +1,9 @@
 import { ObjectId, union } from "./npmDeps.ts";
 import { instance, size, string } from "./npmDeps.ts";
 
-export const objectIdValidation = union([
-	instance(ObjectId),
-	size(string(), 24),
+export const objectIdValidation: ReturnType<typeof union> = union([
+  instance(ObjectId),
+  size(string(), 24),
 ]);
 
 /**
@@ -11,15 +11,15 @@ export const objectIdValidation = union([
  * @public
  */
 export interface Details {
-	/**
-	 *  set of query
-	 */
-	set: Record<string, any>;
-	/**
-	 * get pf query
-	 * What the client wants to return
-	 */
-	get: Record<string, any>;
+  /**
+   *  set of query
+   */
+  set: Record<string, any>;
+  /**
+   * get pf query
+   * What the client wants to return
+   */
+  get: Record<string, any>;
 }
 
 /**
@@ -27,21 +27,21 @@ export interface Details {
  * @public
  */
 export interface TLesanBody {
-	/**
-	 * name of service
-	 * "main" | "blog" | "ecommerce"
-	 */
-	service?: string;
-	/**
-	 * model : schema name that client wants
-	 * act : name of Actions
-	 */
-	model: string;
-	act: string;
-	/**
-	 * details of request set and get
-	 */
-	details: Details;
+  /**
+   * name of service
+   * "main" | "blog" | "ecommerce"
+   */
+  service?: string;
+  /**
+   * model : schema name that client wants
+   * act : name of Actions
+   */
+  model: string;
+  act: string;
+  /**
+   * details of request set and get
+   */
+  details: Details;
 }
 
 /**
@@ -57,7 +57,7 @@ export interface TLesanBody {
  *      }  *
  */
 export interface LesanContenxt {
-	[key: string]: any;
-	Headers: Headers;
-	body: TLesanBody | null;
+  [key: string]: any;
+  Headers: Headers;
+  body: TLesanBody | null;
 }


### PR DESCRIPTION
- Replace remote deno.land imports with jsr aliases for emit and std
- Add compilerOptions.lib and allowlist bundleContent.ts in deno.json publish
- Add explicit return types and improve typings across context, acts, odm, lesan and types
- Remove CancellationToken from npmDeps exports
- Fix Mongo update typing by casting $pull payload as any