### PR TITLE
♻️ Add explicit TypeScript types and imports

### DIFF
--- a/src/core/models/mainRelations/getMainRelations.ts
+++ b/src/core/models/mainRelations/getMainRelations.ts
@@ -1,10 +1,14 @@
+import { IMainRelation } from "../types.ts";
 import { schemaFns, TSchemas } from "../mod.ts";
 
 /**
  * get all of inerRealation of one schema
  * @param schemaName - name of schema that we want inerRealation of it
  */
-export const getMainRelations = (schemasObj: TSchemas, schemaName: string) => {
+export const getMainRelations = (
+  schemasObj: TSchemas,
+  schemaName: string,
+): Record<string, IMainRelation> => {
   const schemas = schemaFns(schemasObj).getSchemas();
   if (!schemas[schemaName]) {
     throw new Error(`Invalid schemaName: ${schemaName}`);

--- a/src/core/models/pure/addPureModel.ts
+++ b/src/core/models/pure/addPureModel.ts
@@ -1,3 +1,4 @@
+import { IModel } from "../types.ts";
 import { IPureFields, schemaFns, TSchemas } from "../mod.ts";
 
 /**
@@ -14,8 +15,8 @@ import { IPureFields, schemaFns, TSchemas } from "../mod.ts";
 export const addPureModel = (
   schemasObj: TSchemas,
   name: string,
-  pureModel: IPureFields
-) => {
+  pureModel: IPureFields,
+): IModel => {
   const schemas = schemaFns(schemasObj).getSchemas();
   return (schemas[name] = {
     pure: pureModel,

--- a/src/core/models/pure/getPureModel.ts
+++ b/src/core/models/pure/getPureModel.ts
@@ -1,6 +1,6 @@
 import { throwError } from "../../utils/throwError.ts";
 import { getPureSchema } from "../mod.ts";
-import { schemaFns, TSchemas } from "../mod.ts";
+import { IPureFields, schemaFns, TSchemas } from "../mod.ts";
 
 /**
  * get pure features of one schema
@@ -10,7 +10,7 @@ export const getPureModel = (
   schemasObj: TSchemas,
   name: string,
   excludes?: string[],
-) => {
+): IPureFields => {
   const schemas = schemaFns(schemasObj).getSchemas();
   return schemas[name]
     ? getPureSchema(schemas, name, excludes)

--- a/src/core/models/pure/getPureModelByNameAndKey.ts
+++ b/src/core/models/pure/getPureModelByNameAndKey.ts
@@ -1,3 +1,4 @@
+import { Struct } from "../../../npmDeps.ts";
 import { schemaFns, TSchemas } from "../mod.ts";
 
 /**
@@ -9,7 +10,7 @@ export const getPureModelByNameAndKey = (
   schemasObj: TSchemas,
   name: string,
   key: string,
-) => {
+): Struct<unknown, unknown> => {
   const schemas = schemaFns(schemasObj).getSchemas();
   const pureModel = schemas[name].pure[key];
   return pureModel;

--- a/src/core/models/relatedRelations/getRelatedRelations.ts
+++ b/src/core/models/relatedRelations/getRelatedRelations.ts
@@ -1,3 +1,4 @@
+import { IRelatedRelation } from "../types.ts";
 import { schemaFns, TSchemas } from "../mod.ts";
 
 /**
@@ -7,7 +8,7 @@ import { schemaFns, TSchemas } from "../mod.ts";
 export const getRelatedRelations = (
   schemasObj: TSchemas,
   schemaName: string,
-) => {
+): Record<string, IRelatedRelation> => {
   const schemas = schemaFns(schemasObj).getSchemas();
   return schemas[schemaName].relatedRelations;
 };

--- a/src/core/models/relation/getRelation.ts
+++ b/src/core/models/relation/getRelation.ts
@@ -1,5 +1,10 @@
 import { schemaFns, TSchemas } from "../mod.ts";
-import { RelationType } from "../types.ts";
+import {
+  IMainRelation,
+  IRelatedRelation,
+  RelationType,
+  TRelation,
+} from "../types.ts";
 
 /**
  * get inerRelatrion or outerRealtion of one schema
@@ -10,7 +15,10 @@ export const getRelation = (
   schemasObjs: TSchemas,
   name: string,
   relationType: RelationType,
-) => {
+):
+  | Record<string, TRelation>
+  | Record<string, IMainRelation>
+  | Record<string, IRelatedRelation> => {
   const schemas = schemaFns(schemasObjs).getSchemas();
   return schemas[name][relationType];
 };

--- a/src/core/models/schema/createEmbedded.ts
+++ b/src/core/models/schema/createEmbedded.ts
@@ -1,3 +1,4 @@
+import { IPureFields } from "../types.ts";
 import { getPureFromMainRelations } from "./getPureFromMainRelations.ts";
 import { getPureFromRelatedRelations } from "./getPureFromRelatedRelations.ts";
 import { TSchemas } from "./mod.ts";
@@ -19,7 +20,10 @@ import { TSchemas } from "./mod.ts";
  *       }),
  * }
  */
-export const createEmbedded = (schemas: TSchemas, schemaName: string) => {
+export const createEmbedded = (
+  schemas: TSchemas,
+  schemaName: string,
+): IPureFields => {
   return {
     ...getPureFromMainRelations(schemas, schemaName),
     ...getPureFromRelatedRelations(schemas, schemaName),

--- a/src/core/models/schema/createStruct.ts
+++ b/src/core/models/schema/createStruct.ts
@@ -1,4 +1,4 @@
-import { assign, object } from "../../../npmDeps.ts";
+import { assign, object, Struct } from "../../../npmDeps.ts";
 import { createEmbedded } from "./createEmbedded.ts";
 import { getPureSchema, TSchemas } from "./mod.ts";
 
@@ -27,7 +27,10 @@ import { getPureSchema, TSchemas } from "./mod.ts";
  *       }),
  *    ),
  */
-export const createStruct = (schemas: TSchemas, schemaName: string) => {
+export const createStruct = (
+  schemas: TSchemas,
+  schemaName: string,
+): Struct<Record<string, unknown>, Record<string, unknown>> => {
   return assign(
     object(getPureSchema(schemas, schemaName)),
     object(createEmbedded(schemas, schemaName)),

--- a/src/core/models/schema/getPureFromMainRelations.ts
+++ b/src/core/models/schema/getPureFromMainRelations.ts
@@ -1,13 +1,14 @@
 import { array, object, optional } from "../../../npmDeps.ts";
 import { getSchema } from "./getSchema.ts";
 import { getPureSchema, TSchemas } from "./mod.ts";
+import { IPureFields } from "../types.ts";
 
 export const getPureFromMainRelations = (
   schemas: TSchemas,
   schemaName: string,
-) => {
+): IPureFields => {
   const schema = getSchema(schemas, schemaName);
-  let pureSchemas = {};
+  let pureSchemas: IPureFields = {};
   for (const property in schema.mainRelations) {
     // console.log(`${property}: ${object[property]}`);
     pureSchemas = {

--- a/src/core/models/schema/getPureFromRelatedRelations.ts
+++ b/src/core/models/schema/getPureFromRelatedRelations.ts
@@ -1,6 +1,7 @@
 import { array, object } from "../../../npmDeps.ts";
 import { getSchema } from "./getSchema.ts";
 import { getPureSchema, TSchemas } from "./mod.ts";
+import { IPureFields } from "../types.ts";
 
 /**
  * extract pure feature of outrelation of schema
@@ -24,9 +25,9 @@ import { getPureSchema, TSchemas } from "./mod.ts";
 export const getPureFromRelatedRelations = (
   schemas: TSchemas,
   schemaName: keyof TSchemas,
-) => {
-  const schema = getSchema(schemas, schemaName);
-  let pureSchemas = {};
+): IPureFields => {
+  const schema = getSchema(schemas, schemaName as string);
+  let pureSchemas: IPureFields = {};
   for (const property in schema.relatedRelations) {
     // console.log(`${property}: ${object[property]}`);
     pureSchemas = {

--- a/src/core/models/schema/getPureOfMainRelations.ts
+++ b/src/core/models/schema/getPureOfMainRelations.ts
@@ -1,3 +1,4 @@
+import { IPureFields } from "../types.ts";
 import { getPureFromMainRelations } from "./getPureFromMainRelations.ts";
 import { getPureSchema } from "./getPureSchema.ts";
 import { TSchemas } from "./mod.ts";
@@ -20,7 +21,7 @@ import { TSchemas } from "./mod.ts";
 export const getPureOfMainRelations = (
   schemas: TSchemas,
   schemaName: string,
-) => {
+): IPureFields => {
   const pureSchema = getPureSchema(schemas, schemaName);
   const pureInrel = getPureFromMainRelations(schemas, schemaName);
 

--- a/src/core/models/schema/getPureSchema.ts
+++ b/src/core/models/schema/getPureSchema.ts
@@ -1,3 +1,4 @@
+import { IPureFields } from "../types.ts";
 import { TSchemas } from "./mod.ts";
 
 /**
@@ -14,7 +15,7 @@ export const getPureSchema = (
   schemas: TSchemas,
   schemaName: string,
   excludes?: string[],
-) => {
+): IPureFields => {
   const schema = schemas[schemaName];
 
   if (!schema) {

--- a/src/core/models/schema/getSchema.ts
+++ b/src/core/models/schema/getSchema.ts
@@ -1,3 +1,4 @@
+import { IModel } from "../types.ts";
 import { TSchemas } from "./mod.ts";
 
 /**
@@ -57,7 +58,7 @@ import { TSchemas } from "./mod.ts";
  * - mainRelation type must be [this type](https://miaadteam.github.io/lesan/api/types/schema/model/TRelation.html)
  */
 
-export const getSchema = (schemas: TSchemas, schemaName: string) => {
+export const getSchema = (schemas: TSchemas, schemaName: string): IModel => {
   const schema = schemas[schemaName];
 
   if (!schema) {

--- a/src/core/models/schema/getSchemaKeys.ts
+++ b/src/core/models/schema/getSchemaKeys.ts
@@ -1,3 +1,4 @@
 import { TSchemas } from "./mod.ts";
 
-export const getSchemasKeys = (schemas: TSchemas) => Object.keys(schemas);
+export const getSchemasKeys = (schemas: TSchemas): string[] =>
+  Object.keys(schemas);

--- a/src/core/odm/delete/deleteOne.ts
+++ b/src/core/odm/delete/deleteOne.ts
@@ -82,7 +82,7 @@ export const deleteOne = async <PureFields extends Document = Document>({
   filter: Filter<PureFields>;
   options?: DeleteOptions;
   hardCascade?: boolean;
-}) => {
+}): Promise<boolean> => {
   const foundedDoc = await db.collection(collection).findOne(
     filter as Filter<Document>,
   );

--- a/src/core/odm/find/aggregation.ts
+++ b/src/core/odm/find/aggregation.ts
@@ -6,7 +6,12 @@
  */
 
 import { TSchemas } from "../../models/mod.ts";
-import { AggregateOptions, Db, Document } from "../../../npmDeps.ts";
+import {
+  AggregateOptions,
+  AggregationCursor,
+  Db,
+  Document,
+} from "../../../npmDeps.ts";
 import { throwError } from "../../utils/mod.ts";
 import { generateProjection } from "../aggregation/mod.ts";
 import { Projection } from "../aggregation/type.ts";
@@ -43,7 +48,7 @@ export const aggregation = (
     options?: AggregateOptions;
     projection?: Projection;
   },
-) => {
+): AggregationCursor<Document> => {
   // Generate projection pipeline stages if a projection is provided
   const genProjection = projection
     ? generateProjection(projection, schemasObj, collection)

--- a/src/core/odm/find/find.ts
+++ b/src/core/odm/find/find.ts
@@ -5,7 +5,13 @@
  * with optional projection support.
  */
 
-import { Db, Document, Filter, FindOptions } from "../../../npmDeps.ts";
+import {
+  Db,
+  Document,
+  Filter,
+  FindCursor,
+  FindOptions,
+} from "../../../npmDeps.ts";
 import { Projection } from "../aggregation/type.ts";
 
 /**
@@ -38,6 +44,6 @@ export const find = ({
   filters,
   projection,
   options,
-}: IFindInput) => {
+}: IFindInput): FindCursor<Document> => {
   return db.collection(collection).find(filters, { ...options, projection });
 };

--- a/src/core/odm/find/findOne.ts
+++ b/src/core/odm/find/findOne.ts
@@ -1,3 +1,4 @@
+import { Document } from "../../../npmDeps.ts";
 import { IFindInput } from "./find.ts";
 
 export const findOne = ({
@@ -6,6 +7,6 @@ export const findOne = ({
   filters,
   projection,
   options,
-}: IFindInput) => {
+}: IFindInput): Promise<Document | null> => {
   return db.collection(collection).findOne(filters, { ...options, projection });
 };

--- a/src/core/odm/insert/insertMany.ts
+++ b/src/core/odm/insert/insertMany.ts
@@ -34,7 +34,7 @@ export const insertMany = async <
   relations?: TInsertRelations<TR>;
   options?: BulkWriteOptions;
   projection?: Projection;
-}) => {
+}): Promise<Document[]> => {
   const foundedSchema = schemaFns(schemasObj).getSchema(collection);
 
   const populatedMainRelations = [];
@@ -163,7 +163,7 @@ export const insertMany = async <
           }
         } else {
           const findWithIds = {
-            _id: { "$in": (relations[rel]!._ids as ObjectId[]) },
+            _id: { "$in": relations[rel]!._ids as ObjectId[] },
           };
 
           const foundedMultiMainRelation = await find({
@@ -373,7 +373,7 @@ export const insertMany = async <
           }
         } else {
           const findWithIds = {
-            _id: { "$in": (relations[rel]!._ids as ObjectId[]) },
+            _id: { "$in": relations[rel]!._ids as ObjectId[] },
           };
 
           const foundedMultiMainRelation = await find({

--- a/src/core/odm/insert/insertOne.ts
+++ b/src/core/odm/insert/insertOne.ts
@@ -31,7 +31,7 @@ export const insertOne = async <
   relations?: TInsertRelations<TR>;
   options?: InsertOneOptions;
   projection?: Projection;
-}) => {
+}): Promise<Document | { _id: ObjectId } | null> => {
   const foundedSchema = schemaFns(schemasObj).getSchema(collection);
 
   const populatedMainRelations = [];

--- a/src/core/odm/relation/addRelation.ts
+++ b/src/core/odm/relation/addRelation.ts
@@ -1,4 +1,4 @@
-import { Db, Document, Filter } from "../../../npmDeps.ts";
+import { Db, Document, Filter, ObjectId } from "../../../npmDeps.ts";
 import { createProjection } from "../../models/createProjection.ts";
 import {
   IRelationsFileds,
@@ -233,7 +233,7 @@ export const addRelation = async <TR extends IRelationsFileds>({
   relations: TInsertRelations<TR>;
   projection?: Projection;
   replace?: boolean;
-}) => {
+}): Promise<Document | { _id: ObjectId } | null> => {
   const foundedSchema = schemaFns(schemasObj).getSchema(collection);
   const foundedDoc = await db.collection(collection).findOne(filters);
 

--- a/src/core/odm/relation/removeRelation.ts
+++ b/src/core/odm/relation/removeRelation.ts
@@ -25,7 +25,7 @@ export const removeRelation = async <TR extends IRelationsFileds>({
   filters: Filter<Document>;
   relations: TInsertRelations<TR>;
   projection?: Projection;
-}) => {
+}): Promise<Document | { _id: ObjectId } | null> => {
   const foundedSchema = schemaFns(schemasObj).getSchema(collection);
   const foundedDoc = await db.collection(collection).findOne(filters);
 

--- a/src/core/odm/update/findOneAndUpdate.ts
+++ b/src/core/odm/update/findOneAndUpdate.ts
@@ -291,7 +291,7 @@ export const findOneAndUpdate = async <PureFields extends Document = Document>(
     };
     projection: Document;
   },
-) => {
+): Promise<Document | null> => {
   const foundedSchema = schemaFns(schemasObj).getSchema(collection);
 
   const pureDocProjection = createProjection(


### PR DESCRIPTION
Add return types to model/schema helpers and ODM functions (find, findOne, aggregation, insertOne/Many, deleteOne, add/removeRelation, findOneAndUpdate) to improve type safety.
Import related interfaces and types (IPureFields, IModel, IMainRelation, IRelatedRelation, Struct, ObjectId) and adjust signatures and minor casts.